### PR TITLE
kitchen: respect system insets

### DIFF
--- a/kitchen/kitchen.go
+++ b/kitchen/kitchen.go
@@ -133,7 +133,14 @@ func loop(w *app.Window) error {
 					}
 				}
 
-				transformedKitchen(gtx, th)
+				layout.Inset{
+					Bottom: e.Insets.Bottom,
+					Left:   e.Insets.Left,
+					Right:  e.Insets.Right,
+					Top:    e.Insets.Top,
+				}.Layout(gtx, func(gtx C) D {
+					return transformedKitchen(gtx, th)
+				})
 				e.Frame(gtx.Ops)
 			}
 		case p := <-progressIncrementer:


### PR DESCRIPTION
This keeps the UI from rendering under the status bar on android.

Before:
![Screenshot_20210227-140205](https://user-images.githubusercontent.com/33375/109402078-ab43a080-7907-11eb-8841-49d4417f3c53.png)

After:
![Screenshot_20210227-141638](https://user-images.githubusercontent.com/33375/109402097-e219b680-7907-11eb-8bef-1ad473eee644.png)

